### PR TITLE
Incorporate search by regex to copy_repo_content

### DIFF
--- a/pubtools/pulplib/_impl/client/client.py
+++ b/pubtools/pulplib/_impl/client/client.py
@@ -340,7 +340,8 @@ class Client(object):
 
         data = {"source_repo_id": origin_repo}
         if criteria:
-            data["criteria"] = criteria
+            prepared_search = search_for_criteria(criteria)
+            data["criteria"] = { "filters": prepared_search.filters }
         if override_config:
             data["override_config"] = override_config
 


### PR DESCRIPTION
To support criteria search a helper method search_for_criteria() need to be called on the Criteria object in order to generate the mongo syntax search string.